### PR TITLE
Fix spec reference for etx2 to point to EBU-TT 1.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -466,7 +466,7 @@ This supersedes the initial registration information in <a href="http://www.w3.o
             </td>
             <td> <code>urn:ebu:tt:exchange:2015-09</code>
             </td>
-            <td> [[!EBU-TT-1-0]]
+            <td> [[!EBU-TT-1-1]]
             </td>
             <td> <a rel="nofollow" class="external text" href="https://tech.ebu.ch/subtitling">EBU</a>
             </td>


### PR DESCRIPTION
Closes #56.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/tt-profile-registry/pull/58.html" title="Last updated on Jan 11, 2019, 3:40 PM UTC (59ed882)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/tt-profile-registry/58/f9f15f6...59ed882.html" title="Last updated on Jan 11, 2019, 3:40 PM UTC (59ed882)">Diff</a>