### PR TITLE
Switch to specref aliases for W3C documents

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,78 +64,25 @@
 
           localBiblio: {
             "IMSC1.0.1": {
-              authors: [
-                  "Pierre-Anthony Lemieux"
-              ],
-              title: "TTML Profiles for Internet Media Subtitles and Captions 1.0.1 (IMSC1)",
-              href: "https://www.w3.org/TR/2018/REC-ttml-imsc1.0.1-20180424/",
-              publisher: "W3C",
-              status: "REC",
-              date: "24 April 2018"
+              aliasOf: "ttml-imsc1.0.1-20180424"
             },
             "IMSC1.1": {
-              authors: [
-                  "Pierre-Anthony Lemieux"
-              ],
-              title: "TTML Profiles for Internet Media Subtitles and Captions 1.1",
-              href: "https://www.w3.org/TR/2018/REC-ttml-imsc1.1-20181108/",
-              publisher: "W3C",
-              status: "REC",
-              date: "08 November 2018"
+              aliasOf: "ttml-imsc1.1-20181108"
             },
             "TTML1-1e": {
-              authors: [
-                  "Glenn Adams"
-              ],
-              title: "Timed Text Markup Language (TTML) 1.0",
-              href: "https://www.w3.org/TR/2010/REC-ttaf1-dfxp-20101118/",
-              publisher: "W3C",
-              status: "REC",
-              date: "18 November 2010"
+              aliasOf: "ttml1-20101118"
             },
             "TTML1-2e": {
-              authors: [
-                  "Glenn Adams"
-              ],
-              title: "Timed Text Markup Language (TTML) 1.0 (2nd Edition)",
-              href: "https://www.w3.org/TR/2013/REC-ttml1-20130924/",
-              publisher: "W3C",
-              status: "REC",
-              date: "24 September 2013"
+              aliasOf: "ttml1-20130924"
             },
             "TTML1-3e": {
-              authors: [
-                  "Glenn Adams",
-                  "Pierre-Anthony Lemieux"
-              ],
-              title: "Timed Text Markup Language (TTML) 1.0 (3rd Edition)",
-              href: "https://www.w3.org/TR/2018/REC-ttml1-20181108/",
-              publisher: "W3C",
-              status: "REC",
-              date: "08 November 2018"
+              aliasOf: "ttml1-20181108"
             },
             "TTML1-SDP-US": {
-              authors: [
-                  "Glenn Adams",
-                  "Monica Martin",
-                  "Sean Hayes"
-              ],
-              title: "TTML Simple Delivery Profile for Closed Captions (US)",
-              href: "https://www.w3.org/TR/2013/NOTE-ttml10-sdp-us-20130205/",
-              publisher: "W3C",
-              status: "WG-NOTE",
-              date: "05 February 2013"
+              aliasOf: "ttml10-sdp-us-20130205"
             },
             "TTML2-1e": {
-              authors: [
-                  "Glenn Adams",
-                  "Cyril Concolato"
-              ],
-              title: "Timed Text Markup Language 2 (TTML2)",
-              href: "https://www.w3.org/TR/2018/REC-ttml2-20181108/",
-              publisher: "W3C",
-              status: "REC",
-              date: "08 November 2018"
+              aliasOf: "ttml2-20181108"
             },
             "UV-DMedia": {
               title: "Common File Format & Media Formats Specification version 2.2",


### PR DESCRIPTION
Avoids duplication of details from the canonical reference data for /TR documents and reduces document size, hence in my view an editorial improvement.

Opening this so that it can be previewed and the delta observed, though I understand at the time of opening the issue @skynavga objects to taking this approach.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/tt-profile-registry/pull/59.html" title="Last updated on Jan 11, 2019, 4:15 PM UTC (c847a99)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/tt-profile-registry/59/5483f8e...c847a99.html" title="Last updated on Jan 11, 2019, 4:15 PM UTC (c847a99)">Diff</a>