### PR TITLE
Add syntax of codecs parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,7 +222,9 @@ codecs-parameter-value
         document, where <code>X+Y</code> means that both <code>X</code> and <code>Y</code> processor profiles must be
         supported, and <code>X|Y</code> means that either <code>X</code> or <code>Y</code> processor profile must be
         supported.</p>
-      <p></p>
+        <p class="note">A similarly-named <code>codecs</code> parameter
+        is defined by [[iso14496-30]] for use in ISOBMFF (MPEG4).</p>
+        <p></p>
     </section> <!-- purpose -->
     <section id="mediatype" class="normative">
       <h2>Media Type Registration</h2>

--- a/index.html
+++ b/index.html
@@ -223,6 +223,14 @@ codecs-parameter-value
         document, where <code>X+Y</code> means that both <code>X</code> and <code>Y</code> processor profiles must be
         supported, and <code>X|Y</code> means that either <code>X</code> or <code>Y</code> processor profile must be
         supported.</p>
+        <p class="note">For example,
+        the <code>codecs</code> string for specifying either a TTML processor that supports
+        [[IMSC1.0.1]] Text Profile or one that supports [[EBU-TT-D-1]]
+        would be `"im1t|etd1"`.
+        The <code>codecs</code> string for specifying a TTML processor that supports
+        the union of sets of required features of both
+        [[IMSC1.0.1]] Text Profile and [[EBU-TT-D-1]]
+        would be `"im1t+etd1"`.</p>
         <p class="note">Another <code>codecs</code> parameter is defined by
         [[RFC6381]] for application/mp4 (ISO BMFF) and
         extended for TTML by [[iso14496-30]].</p>

--- a/index.html
+++ b/index.html
@@ -182,7 +182,8 @@
                 <pre class="nohighlight">
 identifier
 : element                            // element defined by [RFC6381]
-                                     // where "+" and "|" are prohibited characters
+                                     // where "+", "|" and "." are prohibited characters
+                                     // ("." is reserved as a hierarchy delimiter in [RFC6381])
 
 and-group
 : identifier ["+" identifier]*       // no linear white-space is implied or permitted
@@ -420,7 +421,7 @@ codecs-parameter-value
           this registry. An identifier must conform with
           the <code>element</code> non-terminal of [[!RFC6381]]
           and, furthermore, may not contain any of the characters in the regular
-          expression character class <code>[+|]</code>.</p>
+          expression character class <code>[+|.]</code>.</p>
           <div class="note">
             <p>As a consequence of the above syntactic constraints,
               the value space of the <code>codecs</code> parameter described

--- a/index.html
+++ b/index.html
@@ -189,7 +189,7 @@ and-group
                                      // between each token
 
 codecs-parameter-value
-: and_group ["|" and-group]*         // no linear white-space is implied or permitted
+: and-group ["|" and-group]*         // no linear white-space is implied or permitted
                                      // between each token 
 </pre>
               </div>
@@ -222,8 +222,9 @@ codecs-parameter-value
         document, where <code>X+Y</code> means that both <code>X</code> and <code>Y</code> processor profiles must be
         supported, and <code>X|Y</code> means that either <code>X</code> or <code>Y</code> processor profile must be
         supported.</p>
-        <p class="note">A similarly-named <code>codecs</code> parameter
-        is defined by [[iso14496-30]] for use in ISOBMFF (MPEG4).</p>
+        <p class="note">Another <code>codecs</code> parameter is defined by
+        [[RFC6381]] for application/mp4 (ISO BMFF) and
+        extended for TTML by [[iso14496-30]].</p>
         <p></p>
     </section> <!-- purpose -->
     <section id="mediatype" class="normative">

--- a/index.html
+++ b/index.html
@@ -105,6 +105,23 @@
           // !!!! IMPORTANT !!!! MAKE THE ABOVE BLINK IN YOUR HEAD
       };
     </script>
+    <style>
+  table.coldividers td + td { border-left:1px solid gray; text-align: center;}
+  table.syntax { border: 0px solid black; width: 85%; border-collapse: collapse }
+  table.syntax caption { font-weight: bold; text-align: left; padding-bottom: 0.5em }
+  table.syntax th { border: 0px solid black; text-align: left }
+  table.syntax td { border: 0px solid black }
+  table.syntax div { background-color: #ffffc8 }
+  div.exampleInner { background-color: #d5dee3;
+                   border-top-width: 4px;
+                   border-top-style: double;
+                   border-top-color: #d3d3d3;
+                   border-bottom-width: 4px;
+                   border-bottom-style: double;
+                   border-bottom-color: #d3d3d3;
+                   padding: 4px; margin: 0em }
+
+    </style>
   </head>
   <body>
     <section id="abstract">
@@ -123,8 +140,9 @@
       of inline profile definitions) is not considered to be an identifiable,
       shared profile definition, but rather, a private profile definition
       scoped to the document instance in which it is defined.</p>
-    </section>
-    <section id="sotd"></section>
+
+    </section> <!-- abstract -->
+    <section id="sotd"></section> <!-- sotd -->
     <section id="purpose" class="informative">
       <h2>Purpose</h2>
       <p>This document serves two purposes: (1) to define the Media Type
@@ -152,7 +170,34 @@
           specifications) actually used in the resource.</p>
       </div>
       <p>Applications using the entries in this registry are encouraged to support
-        values of the <code>codecs</code> parameter that 
+        the <code>codecs</code> parameter.</p>
+      <p>The <code>codecs</code> parameter value syntax is defined as 
+        <code>codecs-parameter-value</code> as follows,
+        expressed using the syntax expression conventions defined by §2.3 of [[TTML2-1e]].</p>
+      <table class="syntax">
+        <tbody>
+          <tr>
+            <td>
+              <div class="exampleInner">
+                <pre class="nohighlight">
+identifier
+: element                            // element defined by [RFC6381]
+                                     // where "+" and "|" are prohibited characters
+
+and-group
+: identifier ["+" identifier]*       // no linear white-space is implied or permitted
+                                     // between each token
+
+codecs-parameter-value
+: and_group ["|" and-group]*         // no linear white-space is implied or permitted
+                                     // between each token 
+</pre>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p>The <code>codecs</code> parameter may
         employ either (or both) of two combination operators, <code>+</code> (AND) and <code>|</code> (OR), which may be
         used to specify, respectively, that all processor profiles apply
         (simultaneously) or that any processor profile of a list of profiles may
@@ -171,14 +216,14 @@
         both operators in a <code>codecs</code> value expression will
         need to process such combination semantics as a higher level
         protocol outside the scope of [[TTML2-1e]] semantics.</p>
-      <p class="note">The example <code>A+B|C+D|E</code> specifies that a TTML processor that implements
+        <p class="note">The example <code>A+B|C+D|E</code> specifies that a TTML processor that implements
         any one of the <code>A+B</code> or <code>C+D</code> or <code>E</code> processor profiles satisfies
         the requirements to fetch and begin decode/processing of a TTML
         document, where <code>X+Y</code> means that both <code>X</code> and <code>Y</code> processor profiles must be
         supported, and <code>X|Y</code> means that either <code>X</code> or <code>Y</code> processor profile must be
         supported.</p>
       <p></p>
-    </section>
+    </section> <!-- purpose -->
     <section id="mediatype" class="normative">
       <h2>Media Type Registration</h2>
       <p>This section defines the media type "application/ttml+xml",
@@ -363,7 +408,7 @@
           <p>The W3C has change control over this specification.</p>
         </dd>
       </dl>
-    </section>
+    </section> <!-- mediatype -->
     <section id="Registration_Entry_Requirements_and_Update_Process" class="normative">
       <h2>Registration Entry Requirements and Update Process</h2>
       <ol>
@@ -405,7 +450,7 @@
         deleted, there is no intent to re-use deleted profile
         values. That is, the intent is that profile entries are
         "stable".</p>
-    </section>
+    </section> <!-- Registration_Entry_Requirements_and_Update_Process -->
     <section id="registry" class="normative">
       <h2>Registry</h2>
       <p>This section is the registry of short form profile
@@ -658,7 +703,7 @@
             </tr>
           </tbody>
         </table>
-        </section>
-    </section>
+        </section> <!-- registry-profile-designator-specifications -->
+    </section> <!-- registry -->
   </body>
 </html>


### PR DESCRIPTION
Also separate out the encouragement to support from the syntax definition and explanation as per discussion at https://github.com/w3c/tt-profile-registry/issues/71#issuecomment-682033293, and add a note about MP4's `codecs` parameter.

Resolves #71.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/tt-profile-registry/pull/78.html" title="Last updated on Sep 4, 2020, 9:54 AM UTC (a88760d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/tt-profile-registry/78/0f9981c...a88760d.html" title="Last updated on Sep 4, 2020, 9:54 AM UTC (a88760d)">Diff</a>