### PR TITLE
Add publication history to front matter

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
           shortName:            "ttml-profile-registry",
 
           // if there a publicly available Editor's Draft, this is the link
-           edDraftURI:  "https://w3c.github.io/tt-profile-registry/",
+          edDraftURI:  "https://w3c.github.io/tt-profile-registry/",
 
           // editors, add as many as you like
           // only "name" is required
@@ -47,6 +47,12 @@
           subjectPrefix: "[TTML-Profile-Registry]",
 
           otherLinks: [{
+            key: 'Publication history',
+            data: [{
+              value: 'https://www.w3.org/standards/history/ttml-profile-registry',
+              href: 'https://www.w3.org/standards/history/ttml-profile-registry'
+            }]
+          }, {
             key: 'Repository',
             data: [{
               value: 'We are on Github.',


### PR DESCRIPTION
Closes #80 

Respec doesn't appear to have a publication history setting, so adding as an `otherLinks` entry.

This is purely editorial, and approved by WG consensus in principle, so although it needs an approval review to allow the GitHub merge, once that is in place we can go ahead without further review.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/tt-profile-registry/pull/81.html" title="Last updated on Oct 30, 2020, 5:40 PM UTC (db47150)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/tt-profile-registry/81/c79ad15...db47150.html" title="Last updated on Oct 30, 2020, 5:40 PM UTC (db47150)">Diff</a>