### PR TITLE
Add `im4t` for IMSC 1.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
               aliasOf: "ttml-imsc1.2-20200804"
             },
             "IMSC1.3": {
-              aliasOf: "ttml-imsc1.3"
+              aliasOf: "ttml-imsc1.3-20260521"
             },
             "TTML1-1e": {
               aliasOf: "ttml1-20101118"

--- a/index.html
+++ b/index.html
@@ -76,6 +76,9 @@
             "IMSC1.2": {
               aliasOf: "ttml-imsc1.2-20200804"
             },
+            "IMSC1.3": {
+              aliasOf: "ttml-imsc1.3"
+            },
             "TTML1-1e": {
               aliasOf: "ttml1-20101118"
             },
@@ -631,6 +634,16 @@ codecs-parameter-value
               <td> <code>http://www.w3.org/ns/ttml/profile/imsc1.2/text</code>
               </td>
               <td> [[!IMSC1.2]]
+              </td>
+              <td> <a rel="nofollow" class="external text" href="http://www.w3.org/AudioVideo/TT/">TTWG</a>
+              </td>
+            </tr>
+            <tr>
+              <td> <code>im4t</code>
+              </td>
+              <td> <code>http://www.w3.org/ns/ttml/profile/imsc1.3/text</code>
+              </td>
+              <td> [[!IMSC1.3]]
               </td>
               <td> <a rel="nofollow" class="external text" href="http://www.w3.org/AudioVideo/TT/">TTWG</a>
               </td>


### PR DESCRIPTION
Closes 87.

* [X] Amend to point to the IMSC 1.3 Rec URL when known, and at that point remove the Draft status.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/tt-profile-registry/pull/90.html" title="Last updated on May 21, 2026, 4:28 PM UTC (7eb552e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/tt-profile-registry/90/d4705c9...7eb552e.html" title="Last updated on May 21, 2026, 4:28 PM UTC (7eb552e)">Diff</a>